### PR TITLE
Remove hello line to fix syntax error

### DIFF
--- a/.spacemacs
+++ b/.spacemacs
@@ -2,7 +2,7 @@
 ;; This file is loaded by Spacemacs at startup.
 ;; It must be stored in your home directory.
 
-hello
+
 (defun dotspacemacs/layers ()
   "Configuration Layers declaration.
 You should not put any user code in this function besides modifying the variable


### PR DESCRIPTION
This pull request removes the 'hello' line added in the 'dotspacemacs/layers' function, which was causing a syntax error. The change restores the correct structure of the function.